### PR TITLE
Remove stray yield from samgeo utility

### DIFF
--- a/samgeo_utils.py
+++ b/samgeo_utils.py
@@ -3,7 +3,6 @@ from samgeo import SamGeo
 
 def run_samgeo_on_tif(tif_path, checkpoint_path="checkpoints/sam_vit_h_4b8939.pth", outdir="output/"):
     os.makedirs(outdir, exist_ok=True)
-    yield
     basename = os.path.splitext(os.path.basename(tif_path))[0]
     mask_tif = os.path.join(outdir, f"{basename}_mask.tif")
     vector_gpkg = os.path.join(outdir, f"{basename}_mask.gpkg")
@@ -16,6 +15,7 @@ def run_samgeo_on_tif(tif_path, checkpoint_path="checkpoints/sam_vit_h_4b8939.pt
 
     sam.generate(tif_path, output=mask_tif, foreground=True, unique=True)
     sam.tiff_to_vector(mask_tif, vector_gpkg)
-    
+
     return mask_tif, vector_gpkg
+
 # Example usage


### PR DESCRIPTION
## Summary
- remove stray `yield` from `run_samgeo_on_tif`
- ensure function returns mask and vector paths

## Testing
- `pytest` *(fails: No module named 'rasterio'; No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68954f098dd8832abd11938417b979d9