### PR TITLE
Add old_files and geospatial patterns to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ gee_auth/
 .env
 *.pyc
 __pycache__/
+
+old_files/
+*.gpkg


### PR DESCRIPTION
## Summary
- add `old_files/` directory to `.gitignore`
- ignore geospatial `.gpkg` files and ensure existing patterns for output, cache, and TIFF data remain

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy' and 'torch')*
- `pytest --ignore=old_files`


------
https://chatgpt.com/codex/tasks/task_e_68955148542c832a8a19a27c9d01f665