### PR TITLE
Add CLI and Streamlit interfaces for pipeline

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,27 @@
+import streamlit as st
+from pipeline import load_config, run_pipeline
+
+st.title("Geospatial Processing Pipeline")
+
+with st.sidebar:
+    st.header("Parameters")
+    west = st.number_input("West", value=-74.01)
+    south = st.number_input("South", value=40.70)
+    east = st.number_input("East", value=-73.99)
+    north = st.number_input("North", value=40.72)
+    out_dir = st.text_input("Output directory", "output")
+    prompt_text = st.text_area("Prompts (one per line)")
+    run_button = st.button("Run pipeline")
+
+if run_button:
+    bbox = (west, south, east, north)
+    prompts = [p.strip() for p in prompt_text.splitlines() if p.strip()]
+    config = load_config(bbox=bbox, out_dir=out_dir)
+    outputs = run_pipeline(config, prompts)
+
+    st.success("Pipeline complete")
+    st.image(outputs["image"], caption="Downloaded imagery")
+    st.image(outputs["semantic_mask"], caption="LangSAM mask")
+    st.image(outputs["sam2_mask"], caption="SAM2 mask")
+    st.write("Vector data:", outputs["gpkg"])
+    st.write("Summary CSV:", outputs["csv"])

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,40 @@
+import argparse
+from typing import List
+
+from pipeline import load_config, run_pipeline
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the geospatial processing pipeline")
+    parser.add_argument(
+        "--bbox",
+        nargs=4,
+        type=float,
+        metavar=("WEST", "SOUTH", "EAST", "NORTH"),
+        required=True,
+        help="Bounding box coordinates in EPSG:4326",
+    )
+    parser.add_argument(
+        "--out-dir",
+        default="output",
+        help="Directory where outputs will be written",
+    )
+    parser.add_argument(
+        "--prompt",
+        action="append",
+        default=[],
+        help="Text prompt for LangSAM. Can be repeated.",
+    )
+    args = parser.parse_args()
+
+    bbox = tuple(args.bbox)
+    prompts: List[str] = args.prompt
+    config = load_config(bbox=bbox, out_dir=args.out_dir)
+    outputs = run_pipeline(config, prompts)
+
+    for name, path in outputs.items():
+        print(f"{name}: {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/config.py
+++ b/pipeline/config.py
@@ -1,25 +1,38 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable, Optional, Any
+from typing import Any, Optional, Tuple
 import yaml
 
 
 @dataclass
 class PipelineConfig:
-    """Configuration options for the processing pipeline."""
+    """Configuration options for the processing pipeline.
 
-    from pipeline import PipelineConfig
+    Attributes
+    ----------
+    bbox:
+        Bounding box in ``(west, south, east, north)`` order expressed in
+        EPSG:4326 coordinates.
+    zoom:
+        Web mercator zoom level used when downloading imagery tiles.
+    out_dir:
+        Directory where all generated artefacts are written.
+    model_dir:
+        Directory containing model checkpoints.
+    sam2_checkpoint:
+        File name of the SAM2 checkpoint located inside ``model_dir``.
+    box_threshold / text_threshold:
+        Detection thresholds passed through to the segmentation models.
+    """
 
-config = PipelineConfig(
-    bbox=(-74.01, 40.70, -73.99, 40.72),  # west, south, east, north (EPSG:4326)
-    zoom=18,
-    out_dir="output",
-    model_dir="checkpoints",
-    sam2_checkpoint="sam2_hiera_l.pt",
-    box_threshold=0.24,
-    text_threshold=0.24,
-)
+    bbox: Tuple[float, float, float, float] = (-74.01, 40.70, -73.99, 40.72)
+    zoom: int = 18
+    out_dir: str = "output"
+    model_dir: str = "checkpoints"
+    sam2_checkpoint: str = "sam2_hiera_l.pt"
+    box_threshold: float = 0.24
+    text_threshold: float = 0.24
 
 
 def load_config(path: Optional[str] = None, **overrides: Any) -> PipelineConfig:


### PR DESCRIPTION
## Summary
- Implement `PipelineConfig` dataclass with defaults and YAML-based loader.
- Provide `cli.py` for running the pipeline from the command line.
- Add Streamlit `app.py` with sidebar inputs for bounding box, output directory, and prompts.

## Testing
- `python -m py_compile cli.py app.py pipeline/config.py pipeline/pipeline.py pipeline/__init__.py downloader.py segmenter.py vectorizer.py`
- `pytest -q` *(fails: No module named 'samgeo')*


------
https://chatgpt.com/codex/tasks/task_e_68955c32e1f4832a868a332c2780bad4